### PR TITLE
No iteritems in python3

### DIFF
--- a/devserver/modules/cache.py
+++ b/devserver/modules/cache.py
@@ -43,7 +43,7 @@ class CacheSummaryModule(DevServerModule):
             ), duration=stats.get_total_time('cache'))
 
         # set our attributes back to their defaults
-        for k, v in self.old.iteritems():
+        for k, v in self.old.items():
             setattr(cache, k, v)
 
 


### PR DESCRIPTION
Cache module on python3 raises error

```
AttributeError: 'dict' object has no attribute 'iteritems'
```
